### PR TITLE
feat: add 'gpt-4o' and 'gpt-4-turbo' models

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,12 @@ A translator app that uses OpenAI GPT-3 to translate between languages. It is a 
 
 https://translator.lance.moe/
 
-Support ChatGPT engine (GPT 3.5).
+Support models:
+
+- GPT-3.5 Turbo (ChatGPT engine)
+- GPT-4
+- GPT-4 Turbo
+- GPT-4o
 
 <img width="970" alt="image" src="https://user-images.githubusercontent.com/18505474/222828200-948eef23-bf59-43af-ac27-1484c2bcd406.png">
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -9,10 +9,11 @@ export const GPT_MODELS = [
   'gpt-4',
   'gpt-4-0314',
   'gpt-4-0614',
-  'gpt-4-1106-preview',
   'gpt-4-32k',
   'gpt-4-32k-0314',
   'gpt-4-32k-0614',
+  'gpt-4-turbo',
+  'gpt-4o',
 ] as const;
 
 export const OPENAI_MODELS = [...GPT_MODELS, 'text-davinci-003', 'text-davinci-002'] as const;
@@ -31,10 +32,11 @@ export const OPENAI_MODELS_TITLES: Record<OpenAIModel, string> = {
   'gpt-4': 'gpt-4',
   'gpt-4-0314': 'gpt-4-0314',
   'gpt-4-0614': 'gpt-4-0614',
-  'gpt-4-1106-preview': 'gpt-4-1106-preview',
   'gpt-4-32k': 'gpt-4-32k (testing)',
   'gpt-4-32k-0314': 'gpt-4-32k-0314 (testing)',
   'gpt-4-32k-0614': 'gpt-4-32k-0614 (testing)',
+  'gpt-4-turbo': 'gpt-4-turbo',
+  'gpt-4o': 'gpt-4o',
 } as const;
 
 export const OPENAI_MODELS_DESCRIPTION: Record<OpenAIModel, string> = {
@@ -48,10 +50,11 @@ export const OPENAI_MODELS_DESCRIPTION: Record<OpenAIModel, string> = {
   'gpt-4': 'GPT-4',
   'gpt-4-0314': 'GPT-4 0314',
   'gpt-4-0614': 'GPT-4 0614',
-  'gpt-4-1106-preview': 'GPT-4 1106 preview',
   'gpt-4-32k': 'GPT-4 32K',
   'gpt-4-32k-0314': 'GPT-4 32K 0314',
   'gpt-4-32k-0614': 'GPT-4 32K 0614',
+  'gpt-4-turbo': 'GPT-4 turbo',
+  'gpt-4o': 'GPT-4o',
 } as const;
 
 export const LANGUAGES = {


### PR DESCRIPTION
- Introduce the new `gpt-4o` model.
- Replace `gpt-4-1106-preview` with the continuously updated `gpt-4-turbo`.

Tested on local build
![Screenshot 2024-05-14 at 10 33 42 AM](https://github.com/LanceMoe/openai-translator/assets/15743306/e7d00036-5f58-434d-b91e-83bfa784db28)
